### PR TITLE
Updating scala, akka, akka http, scalatest to latest versions

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -6,20 +6,23 @@ description := "Openid implementation for Akka HTTP"
 
 version := "0.1.0"
 
-scalaVersion := "2.11.7"
+scalaVersion := "2.12.3"
 
 scalacOptions := Seq("-encoding", "utf8")
 
+val   akkaV     = "2.5.3"
+val   akkaHttpV = "10.0.9"
+
 libraryDependencies ++= {
   Seq(
-    "com.typesafe.akka" %% "akka-http-experimental" % "2.0.2",
-    "com.typesafe.akka" %% "akka-http-spray-json-experimental" % "2.0.2",
+    "com.typesafe.akka" %% "akka-http"               % akkaHttpV,
+    "com.typesafe.akka" %% "akka-http-spray-json"    % akkaHttpV,
     "org.scala-lang.modules" %% "scala-xml" % "1.0.5",
     "com.nimbusds" % "nimbus-jose-jwt" % "4.11",
 
-    "org.scalatest" %% "scalatest" % "2.2.6" % "test",
-    "com.typesafe.akka" %% "akka-testkit" % "2.3.12" % "test",
-    "com.typesafe.akka" %% "akka-http-testkit-experimental" % "2.0.2" % "test"
+    "org.scalatest" %% "scalatest" % "3.0.1" % "test",
+    "com.typesafe.akka" %% "akka-testkit"            % akkaV % "test",
+    "com.typesafe.akka" %% "akka-http-testkit"       % akkaHttpV % "test"
   )
 }
 

--- a/src/test/scala/k/akka/openid/OpenidRouterSpec.scala
+++ b/src/test/scala/k/akka/openid/OpenidRouterSpec.scala
@@ -14,6 +14,8 @@ import scala.concurrent.duration.FiniteDuration
 class OpenidRouterSpec extends WordSpecLike with ScalatestRouteTest {
   implicit val sessionDuration = new FiniteDuration(1, TimeUnit.MINUTES)
 
+  implicit def toScalaOption[A](underlying: java.util.Optional[A]):Option[A] = if (underlying.isPresent) Some(underlying.get) else None
+
   val providers = Seq(OpenidProviderMock(OpenidProviderMockSettings("tst")))
   val routerSettings = OpenidRouterSettings(
     prefix = Some("session"),


### PR DESCRIPTION
Updates to scala 2.12.3, akka http 10.0.9, akka (testkit) 2.5.3, and scalatest 3.0.1 (all latest as of the date of this pull request).